### PR TITLE
Add docs manifest and readme

### DIFF
--- a/wrappers/ipfs-http-client/build/docs/pages/readme.md
+++ b/wrappers/ipfs-http-client/build/docs/pages/readme.md
@@ -1,0 +1,37 @@
+# The IPFS HTTP Client Wrap
+
+The IPFS HTTP Client wrap allows for basic interaction with IPFS endpoints, such as `ipfs.wrappers.io` which serves Polywrap wraps.
+
+## Integrate
+
+### Step 1: Polywrap Client
+
+The Polywrap client comes with the IPFS HTTP Client wrap pre-bundled. Currently Polywrap has clients available in:
+- JavaScript / TypeScript
+- Python
+- Rust
+- Swift
+
+### Step 2: Run!
+
+With your client successfully configured, you can now run any function on the The IPFS HTTP Client wrap wrap with ease.
+
+You can execute functions in TypeScript with the `client.invoke(...)` syntax like so:
+```typescript
+await client.invoke({
+  uri: "wrap://ens/wraps.eth:ipfs-http-client@1.0.0",
+  method: "cat",
+  args: {...}
+});
+```
+
+Or you can keep it type-safe by using Polywrap's `codegen` like so:
+```typescript
+await Ipfs.cat({...});
+```
+
+If you'd like to generate typings for the The IPFS HTTP Client wrap wrap, you can see an example of this in [Polywrap's Quick Start guide](https://docs.polywrap.io/quick-start#generating-types-codegen).
+
+## Support
+
+For any questions or problems related to the The IPFS HTTP Client wrap wrap or Polywrap at large, please visit our [Discord](https://discord.polywrap.io).

--- a/wrappers/ipfs-http-client/build/docs/polywrap.docs.json
+++ b/wrappers/ipfs-http-client/build/docs/polywrap.docs.json
@@ -1,0 +1,1 @@
+{"format":"0.1.0","description":"Interact with the Uniswap V3 contract.","website":"https://polywrap.io","repository":"https://github.com/polywrap/","readme":"pages/readme.md"}

--- a/wrappers/ipfs-http-client/docs/readme.md
+++ b/wrappers/ipfs-http-client/docs/readme.md
@@ -1,0 +1,37 @@
+# The IPFS HTTP Client Wrap
+
+The IPFS HTTP Client wrap allows for basic interaction with IPFS endpoints, such as `ipfs.wrappers.io` which serves Polywrap wraps.
+
+## Integrate
+
+### Step 1: Polywrap Client
+
+The Polywrap client comes with the IPFS HTTP Client wrap pre-bundled. Currently Polywrap has clients available in:
+- JavaScript / TypeScript
+- Python
+- Rust
+- Swift
+
+### Step 2: Run!
+
+With your client successfully configured, you can now run any function on the The IPFS HTTP Client wrap wrap with ease.
+
+You can execute functions in TypeScript with the `client.invoke(...)` syntax like so:
+```typescript
+await client.invoke({
+  uri: "wrap://ens/wraps.eth:ipfs-http-client@1.0.0",
+  method: "cat",
+  args: {...}
+});
+```
+
+Or you can keep it type-safe by using Polywrap's `codegen` like so:
+```typescript
+await Ipfs.cat({...});
+```
+
+If you'd like to generate typings for the The IPFS HTTP Client wrap wrap, you can see an example of this in [Polywrap's Quick Start guide](https://docs.polywrap.io/quick-start#generating-types-codegen).
+
+## Support
+
+For any questions or problems related to the The IPFS HTTP Client wrap wrap or Polywrap at large, please visit our [Discord](https://discord.polywrap.io).

--- a/wrappers/ipfs-http-client/polywrap.docs.yaml
+++ b/wrappers/ipfs-http-client/polywrap.docs.yaml
@@ -1,0 +1,5 @@
+format: 0.1.0
+description: Interact with the Uniswap V3 contract.
+website: https://polywrap.io
+repository: https://github.com/polywrap/
+readme: ./docs/readme.md

--- a/wrappers/ipfs-http-client/polywrap.yaml
+++ b/wrappers/ipfs-http-client/polywrap.yaml
@@ -1,4 +1,4 @@
-format: 0.2.0
+format: 0.4.0
 project:
   name: ipfs-http-client-as
   type: wasm/assemblyscript
@@ -6,5 +6,4 @@ source:
   schema: ./src/schema.graphql
   module: ./src/index.ts
 extensions:
-  deploy: ./polywrap.deploy.yaml
-
+  docs: ./polywrap.docs.yaml


### PR DESCRIPTION
This PR introduces documentation for the ipfs-http-client wrap itself, which will be later hosted on Wrapscan.

A docs manifest with a basic, but usable readme was added.